### PR TITLE
dockerize & tests

### DIFF
--- a/.dockeringore
+++ b/.dockeringore
@@ -1,0 +1,1 @@
+/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /*.iml
 /.nrepl-port
 /.idea
+/yarn-error.log
+/out/node-tests.js

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,9 @@
+FROM node:10
+
+RUN echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list && \
+    apt-get update && \
+    apt-get install -t jessie-backports openjdk-8-jre-headless -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    update-java-alternatives -s java-1.8.0-openjdk-amd64
+
+RUN yarn global add shadow-cljs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "2"
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+    volumes:
+      - ./:$PWD
+    working_dir: $PWD
+    ports:
+      - "8020:8020" # app
+      - "9630:9630" # ws for hot code reload
+      - "9000:9000" # nrepl
+    command: bash -c "yarn install && yarn shadow-cljs server"
+
+  release:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+    volumes:
+      - ./:$PWD
+    working_dir: $PWD
+    command: bash -c "yarn install && yarn shadow-cljs release app"

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,12 +1,15 @@
 ;; shadow-cljs configuration
 {:source-paths
- ["src"]
+ ["src" "test"]
 
  :dependencies
  []
 
+ :nrepl
+ {:port 9000}
+
  :builds
- {:app {:target :browser
+ {:app {:target     :browser
         :output-dir "public/js"
         :asset-path "/js"
 
@@ -17,5 +20,10 @@
         ;; start a development http server on http://localhost:8020
         :devtools
         {:http-root "public"
-         :http-port 8020}
-        }}}
+         :http-host "0.0.0.0"
+         :http-port 8020}}
+
+  :test {:target    :node-test
+         :output-to "out/node-tests.js"
+         :ns-regexp "-test$"
+         :autorun   true}}}

--- a/test/starter/browser_test.cljs
+++ b/test/starter/browser_test.cljs
@@ -1,0 +1,19 @@
+(ns starter.browser-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [starter.browser :as browser]))
+
+(deftest exported-function
+  (testing "start"
+    (is (fn? browser/start))
+    (is (-> #'browser/start
+            meta
+            :dev/after-load)))
+
+  (testing "stop"
+    (is (fn? browser/stop))
+    (is (-> #'browser/stop
+            meta
+            :dev/before-load)))
+
+  (testing "init"
+    (is (fn? browser/init))))


### PR DESCRIPTION
this PR is a bag of two things. 
- examples of tests (which is necessary in my opinion and lack of it looks odd for me)
- dockerize development. For me is convenient to have only installed docker and docker-compose to run a project. If it is not a scope of this repo I'll rename my for and improve it little more to be `docker-shadow-cljs` :D or something similar.
I can split this PR if needed.

BTW. Great project! without shadow-cljs dealing with npm was big pain. 